### PR TITLE
Set memory size as 512

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,5 +21,5 @@ resource "aws_lambda_function" "hello_world" {
   role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
   handler       = "exports.test"
   runtime       = "nodejs12.x"
-  memory_size   = 1024 # <<<<< Try changing this to 512 to compare costs
+  memory_size   = 512 # <<<<< Try changing this to 1024 to compare costs
 }


### PR DESCRIPTION
This PR updates the `memory_size` property on the `aws_lambda_function` Terraform resource.

